### PR TITLE
Pass option for Ajv and export its instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,33 +2,37 @@
 
 const Ajv = require('ajv');
 
-module.exports = (chai, util) => {
+function _createPlugin(chai, util, options) {
     const assert = chai.assert;
 
-    let options = null;
     let ajv = new Ajv(options);
 
     // export ajv to chai
     chai.ajv = ajv;
 
-    // add the method to chai
-    chai.Assertion.addMethod('jsonSchema', function (schema, msg) {
-        let data = this._obj;
+    /**
+     * Test if {value} matches the {schema}
+     */
+    chai.Assertion.addMethod('jsonSchema', function (schema) {
+        const value = this._obj;
 
         assert.ok(schema, 'schema');
 
-        let validate = ajv.compile(schema);
-        let valid = validate(data);
-        let detail = '';
-        if (!valid) {
-            let errors = validate.errors;
-            detail =  `${JSON.stringify(errors, true, 2)}`;
-        }
+        const valid = ajv.validate(schema, value);
 
-        // pass formatted string to mocha.
-        this.assert(
-            valid,
-            `expected value not match the json-schema\n${detail}`
-        );
+        if (!valid) {
+            this.assert(
+                valid,
+                "expected value not match the json-schema\n" + JSON.stringify(ajv.errors, null, '  ')
+            );
+        }
     });
+}
+
+module.exports = _createPlugin;
+
+module.exports.withOptions = function(options) {
+    return function(chai, utils) {
+        return _createPlugin(chai, utils, options);
+    }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ module.exports = (chai, util) => {
     let ajv = new Ajv(options);
 
     // export ajv to chai
-    chai.ajv = Ajv;
+    chai.ajv = ajv;
 
     // add the method to chai
     chai.Assertion.addMethod('jsonSchema', function (schema, msg) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,21 @@ function _createPlugin(chai, util, options) {
             );
         }
     });
+
+    /**
+     * Test if {schema} is valid
+     */
+    chai.Assertion.addProperty('validJsonSchema', function () {
+        const schema = this._obj;
+        const valid = ajv.validateSchema(schema);
+
+        if(!valid) {
+            this.assert(
+                valid,
+                "value is not a valid JSON Schema:\n" + util.inspect(ajv.errors, null, null)
+            );
+        }
+    });
 }
 
 module.exports = _createPlugin;

--- a/test/basic.js
+++ b/test/basic.js
@@ -5,6 +5,10 @@ chai.use(require('../src/index.js'));
 const expect = chai.expect;
 
 describe('basic test', function () {
+    it('chai.ajv should be instance of Ajv', function () {
+       expect(chai.ajv).to.be.instanceof(require('ajv'));
+    });
+
     it('apple should match fruit schema.', function () {
         let apple = {
             name: 'foo',


### PR DESCRIPTION
Hi,

Will you consider merging this pull request?

I've added:
1. A method to pass options to Ajv during plugin instantiation. Like this:
```
chai.use(require('chai-json-schema-ajv').withOptions({schemas: require('./schemas')}));
```

2. Export an Ajv instance instead of class object
3. An assertion for JSON Schema validity